### PR TITLE
tk71.c: Write MAC addresses into hardware

### DIFF
--- a/board/karo/tk71/tk71.c
+++ b/board/karo/tk71/tk71.c
@@ -163,11 +163,20 @@ static void mv_phy_88e1118_init(char *name)
 	printf("88E1118 Initialized on %s\n", name);
 }
 
+extern void port_uc_addr_set(void *regs, u8 * p_addr);
+
 /* Configure and enable Switch and PHY */
 void reset_phy(void)
 {
 	/* configure and initialize PHY */
 	mv_phy_88e1118_init("egiga0");
 
+    u8 maddr[16];
+    if (eth_getenv_enetaddr("ethaddr", maddr)){
+        port_uc_addr_set((void *)KW_EGIGA0_BASE, maddr);
+    }
+    if (eth_getenv_enetaddr("eth1addr", maddr)){
+        port_uc_addr_set((void *)KW_EGIGA1_BASE, maddr);
+    }
 }
 #endif

--- a/drivers/net/mvgbe.c
+++ b/drivers/net/mvgbe.c
@@ -368,7 +368,7 @@ static int port_uc_addr(struct mvgbe_registers *regs, u8 uc_nibble,
 /*
  * port_uc_addr_set - This function Set the port Unicast address.
  */
-static void port_uc_addr_set(struct mvgbe_registers *regs, u8 * p_addr)
+void port_uc_addr_set(struct mvgbe_registers *regs, u8 * p_addr)
 {
 	u32 mac_h;
 	u32 mac_l;


### PR DESCRIPTION
As the TK71 is run without a device tree or any other suitable means of
passing MAC addresses to the Linux Kernel, the kernel expects that all
MAC addresses are pre-configued in the hardware.